### PR TITLE
Fix setup typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ if __name__ == '__main__':
         description='AtomDB',
         long_description=README,
         packages=['atomdb'],
-        package_dir={'atomdb': 'atomdb'}
+        package_dir={'atomdb': 'atomdb'},
         include_package_data=True,
     )


### PR DESCRIPTION
Running pip install, I got a syntax error of a comma missing. With this change it installs without error.