### PR TITLE
Promolecule: add default multiplicities for non-int charge (#82)

### DIFF
--- a/atomdb/promolecule.py
+++ b/atomdb/promolecule.py
@@ -622,7 +622,7 @@ def make_promolecule(
     if mults is None:
         # Force non-int charge to be integer here; will be overwritten below.
         mults = []
-        for (atnum, charge) in zip(atnums, charges):
+        for atnum, charge in zip(atnums, charges):
             if isinstance(charge, Integral):
                 mults.append(MULTIPLICITIES[(atnum, charge)])
             else:


### PR DESCRIPTION
Fixes #82.

The code example,
```python3
from atomdb import make_promolecule
import numpy as np


atnums = [7]
charges = [0.1]
atcoords = np.array([[0.0, 0.0, 0.0]])

# Build a promolecule
promol = make_promolecule(
    atnums,
    atcoords,
    charges=charges,
    units="bohr",
    dataset="gaussian",
)
```
now runs, but it isn't able to construct a Promolecule instance:
```
ValueError: Unable to construct species with non-integer charge/spin from database entries
```

This is a valid error to get, but it's not ideal. This is why, when making a Promolecule with non-integer charges, I suggested that the user should also specify the multiplicities.

Open to suggestions.