### PR TITLE
Removed support for Python versions less than 3.9

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        py: ["3.7", "3.9", "3.10", "3.11"]
+        py: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: "actions/checkout@v3"
@@ -32,6 +32,7 @@ jobs:
 
       - name: Install extra test dependencies
         run: |
+          pip install --upgrade pip
           pip install .[test_extra]
 
       - name: Run pytest default tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ authors = [
 description = "AtomDB is a database of atomic and ionic properties."
 readme = "README.rst"
 license = {text = "GPL-3.0-or-later"}
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
    'Development Status :: 0 - Released',
     'Environment :: Console',
@@ -36,8 +36,6 @@ classifiers = [
     'Intended Audience :: Science/Research',
     "Intended Audience :: Education",
     "Natural Language :: English",
-    'Programming Language :: Python :: 3.7',
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This PR addressed issue #95 regarding our broken github workflow due to incompatibility of some of atomdb's development dependencies with Python 3.7

We upgraded the support from Python 3.7 to 3.9 in the project.toml file and updated github's pytest workflow to reflect this change.