### PR TITLE
Fix colab button links in website

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -48,8 +48,7 @@ jobs:
     - name: Create soft links
       run: |
         cd website
-        ln -s ../docs/notebooks ./examples
-        ln -s ../docs/notebooks/images ./examples/images
+        cp -lR ../docs/notebooks ./examples
         ln -s ../docs/source ./api
         cd ../
 


### PR DESCRIPTION
This PR addresses issue #103 

During the deployment of the website, to link to the folder containing the tutorial notebooks (docs/notebook), the symbolic link command ``ln -s`` was replaced by ``cp -lR``.