### PR TITLE
Fix the failing long description of PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ authors = [
   { name="QC-Devs Community", email="qcdevs@gmail.com" },
 ]
 description = "AtomDB is a database of atomic and ionic properties."
-readme = "README.rst"
+readme = "README.md"
 license = {text = "GPL-3.0-or-later"}
 requires-python = ">=3.9"
 classifiers = [


### PR DESCRIPTION
The original codes didn't update the  variable for `readme`, which led to an error in rendering problem of PyPI. This PR fixes that.