### PR TITLE
Refactor the `compile` function as it's built-in function (fixes #109)

### DIFF
--- a/atomdb/__init__.py
+++ b/atomdb/__init__.py
@@ -26,7 +26,7 @@ from atomdb.promolecule import Promolecule
 
 from atomdb.periodic import element_number, element_symbol, element_name
 
-from atomdb.species import compile, load, dump, raw_datafile
+from atomdb.species import compile_species, load, dump, raw_datafile
 
 from atomdb.promolecule import make_promolecule
 
@@ -38,7 +38,7 @@ __all__ = [
     "element_number",
     "element_symbol",
     "element_name",
-    "compile",
+    "compile_species",
     "load",
     "dump",
     "raw_datafile",

--- a/atomdb/__main__.py
+++ b/atomdb/__main__.py
@@ -17,7 +17,7 @@ r"""AtomDB console script."""
 
 from argparse import ArgumentParser
 
-from atomdb import compile, load
+from atomdb import compile_species, load
 
 
 # Initialize command line argument parser
@@ -31,7 +31,7 @@ command = parser.add_argument_group("commands")
 command_group = command.add_mutually_exclusive_group(required=True)
 
 command_group.add_argument(
-    "-c", "--compile", action="store_true", help="compile a species into the database"
+    "-c", "--compile_species", action="store_true", help="compile_species a species into the database"
 )
 
 command_group.add_argument(
@@ -60,7 +60,7 @@ if __name__ == "__main__":
 
     if args.compile:
 
-        compile(args.elem, args.charge, args.mult, args.exc, args.dataset)
+        compile_species(args.elem, args.charge, args.mult, args.exc, args.dataset)
 
     elif args.query:
 

--- a/atomdb/species.py
+++ b/atomdb/species.py
@@ -47,7 +47,7 @@ from atomdb.periodic import element_symbol
 
 __all__ = [
     "Species",
-    "compile",
+    "compile_species",
     "dump",
     "load",
     "raw_datafile",
@@ -712,7 +712,7 @@ class Species:
         pass
 
 
-def compile(
+def compile_species(
     elem,
     charge,
     mult,


### PR DESCRIPTION
This PR fixes the redefining the built-in function `compile`. More explanations can be found at #109. 