### PR TITLE
doc: added notebook on how to add custom datasets (#155)

### DIFF
--- a/website/examples/how_to_add_custom_datasets.ipynb
+++ b/website/examples/how_to_add_custom_datasets.ipynb
@@ -1,0 +1,148 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3793337f",
+   "metadata": {},
+   "source": [
+    "# How to Add Custom Datasets to AtomDB\n",
+    "This notebook walks through the steps required to integrate a custom dataset into AtomDB."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b1092f0",
+   "metadata": {},
+   "source": [
+    "## 1. Import Required Libraries\n",
+    "```python\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "import atomdb\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a9eb2a6",
+   "metadata": {},
+   "source": [
+    "## 2. Define Custom Dataset Structure\n",
+    "A custom dataset must live under `atomdb/datasets/<your_name>/` and include a `run.py` file exposing a `run(elem, charge, mult, exc)` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff2cb2e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example directory layout:\n",
+    "# atomdb/datasets/custom_ds/\n",
+    "# └── run.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2011bc7d",
+   "metadata": {},
+   "source": [
+    "## 3. Implement Data Loading Function\n",
+    "In `run.py`, write a loader similar to Slater or Gaussian that returns a dictionary of fields for AtomDB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e22dcc8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# run.py template\n",
+    "def run(elem, charge, mult, exc):\n",
+    "    # Load or generate raw data file path\n",
+    "    raw_file = f\"data/{elem}_{charge}_{mult}.dat\"\n",
+    "    # Parse and return dictionary of fields\n",
+    "    return { 'elem': elem, 'charge': charge, 'mult': mult, 'raw': raw_file }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b98d14a5",
+   "metadata": {},
+   "source": [
+    "## 4. Integrate Custom Dataset with AtomDB\n",
+    "Point AtomDB to your folder by passing its name to the CLI or API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71aca683",
+   "metadata": {
+    "vscode": {
+     "languageId": "bash"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# From project root\n",
+    "atomdb -c custom_ds H 0 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ffcda12",
+   "metadata": {},
+   "source": [
+    "## 5. Validate Custom Dataset Integration\n",
+    "Load your species and inspect fields to confirm correct integration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fbf65a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from atomdb import load\n",
+    "species = load('H', 0, 1, 0, 'custom_ds')\n",
+    "print(species)\n",
+    "print(species.raw)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c046bf8e",
+   "metadata": {},
+   "source": [
+    "## 6. Example: Using the Custom Dataset\n",
+    "Compute a property (e.g., density) with your new data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3073c576",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Assuming your loader provides raw density points\n",
+    "import numpy as np\n",
+    "dens = np.loadtxt(species.raw)\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.plot(dens[:,0], dens[:,1])\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Closes #155

This adds a step-by-step Jupyter notebook under website/examples explaining how to integrate
a custom dataset into AtomDB.